### PR TITLE
fix(#53) :: 실종자 등록 API 데이터베이스 오류 수정

### DIFF
--- a/src/main/java/baro/baro/domain/common/exception/ApiErrorResponse.java
+++ b/src/main/java/baro/baro/domain/common/exception/ApiErrorResponse.java
@@ -21,4 +21,13 @@ public record ApiErrorResponse(String code, String message, int status, LocalDat
                 LocalDateTime.now()
         );
     }
+
+    public static ApiErrorResponse of(String code, String message, int status) {
+        return new ApiErrorResponse(
+                code,
+                message,
+                status,
+                LocalDateTime.now()
+        );
+    }
 }

--- a/src/main/java/baro/baro/domain/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/baro/baro/domain/common/exception/GlobalExceptionHandler.java
@@ -217,7 +217,7 @@ public class GlobalExceptionHandler {
         log.error("Database exception occurred: {}", e.getMessage());
         return ResponseEntity
                 .status(ErrorCode.INTERNAL_ERROR.getStatus())
-                .body(ApiErrorResponse.of("DATABASE_ERROR", "데이터베이스 오류가 발생했습니다."));
+                .body(ApiErrorResponse.of("DATABASE_ERROR", "데이터베이스 오류가 발생했습니다.", ErrorCode.INTERNAL_ERROR.getStatus()));
     }
 
     /**

--- a/src/main/java/baro/baro/domain/missingperson/repository/MissingCaseRepository.java
+++ b/src/main/java/baro/baro/domain/missingperson/repository/MissingCaseRepository.java
@@ -15,7 +15,7 @@ public interface MissingCaseRepository extends JpaRepository<MissingCase, Long> 
     @Query("SELECT m FROM MissingCase m WHERE m.missingPerson.id = :missingPersonId and m.caseStatus = 'OPEN'")
     Optional<MissingCase> findByMissingPersonId(Long missingPersonId);
 
-    @Query("SELECT COUNT(m) FROM MissingCase m WHERE m.reportedBy = :userId and m.caseStatus = 'OPEN'")
+    @Query("SELECT COUNT(m) FROM MissingCase m WHERE m.reportedBy.id = :userId and m.caseStatus = 'OPEN'")
     long countByReportedById(Long userId);
 
     Optional<MissingCase> findByMissingPersonAndCaseStatus(MissingPerson missingPerson, CaseStatusType caseStatusType);


### PR DESCRIPTION
- MissingCaseRepository: JPQL 쿼리 타입 불일치 수정 (m.reportedBy → m.reportedBy.id)
- ApiErrorResponse: status 파라미터를 받는 오버로드 메서드 추가
- GlobalExceptionHandler: 데이터베이스 오류 응답에 정확한 HTTP status 전달